### PR TITLE
Preserve BCH API compatibility in the QECCore move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Allow Nemo 0.56 in QuantumClifford and QECCore, and update Oscar quotient-ring examples for Nemo's new finite-field representation.
 - Avoid runtime dispatch when resetting qubits in `MixedDestabilizer` states.
+- Move the classical `BCH` code type to `QECCore` while keeping `QuantumClifford.ECC.BCH` as the same type for compatibility, and reject nonpositive error-correction parameters.
 
 ## v0.11.7 - 2026-08-06
 

--- a/lib/QECCore/CHANGELOG.md
+++ b/lib/QECCore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## unreleased
+
+- Add `BCH`, moved from `QuantumClifford.ECC`, with generator-polynomial and parity-matrix methods provided by the Nemo extension.
+
 ## v0.1.3 - 2026-03-03
 
 - `hasmetachecs`method added (not public).

--- a/lib/QECCore/ext/QECCoreNemoExt/QECCoreNemoExt.jl
+++ b/lib/QECCore/ext/QECCoreNemoExt/QECCoreNemoExt.jl
@@ -7,12 +7,11 @@ import Nemo
 import Nemo: GF, gen, matrix, rank, transpose, polynomial_ring, evaluate, FqFieldElem,
     FqPolyRingElem, degree, is_irreducible, gcd, derivative, inv, coeff, is_monic, one,
     minpoly, lcm, is_zero, finite_field
-import QECCore: code_k, parity_matrix_x, parity_matrix_z, parity_matrix, generator_polynomial
+import QECCore: AbstractPolynomialCode, BCH, code_k, code_n, generator_polynomial,
+    parity_matrix, parity_matrix_x, parity_matrix_z, random_Goppa_code
 
 import Random
 import Random: MersenneTwister, GLOBAL_RNG, AbstractRNG, rand
-
-import QECCore: random_Goppa_code, code_k, code_n
 
 function QECCore.code_k(c::AbstractCSSCode)
     n = code_n(c)

--- a/lib/QECCore/ext/QECCoreNemoExt/bch.jl
+++ b/lib/QECCore/ext/QECCoreNemoExt/bch.jl
@@ -1,51 +1,3 @@
-
-abstract type AbstractPolynomialCode <: AbstractCECC end
-
-"""
-The family of Bose–Chaudhuri–Hocquenghem (BCH) codes, as discovered in 1959 by
-Alexis Hocquenghem [hocquenghem1959codes](@cite), and independently in 1960 by
-Raj Chandra Bose and D.K. Ray-Chaudhuri [bose1960class](@cite).
-
-The BCH code, denoted as `BCH(m, t)`, is defined by `m`, a positive integer that
-specifies the degree of the finite (Galois) field `GF(2ᵐ)`, and `t`, a positive
-integer that indicates the number of correctable errors. The binary parity check
-matrix can be obtained from the following matrix over ``GF(2ᵐ)`` field elements:
-
-```math
-\\begin{aligned}
-\\begin{matrix}
-1 & (\\alpha^1)^1 & (\\alpha^1)^2 & (\\alpha^1)^3 & \\dots & (\\alpha^1)^{n-1} \\\\
-1 & (\\alpha^3)^1 & (\\alpha^3)^2 & (\\alpha^3)^3 & \\dots & (\\alpha^3)^{n-1} \\\\
-1 & (\\alpha^5)^1 & (\\alpha^5)^2 & (\\alpha^5)^3 & \\dots & (\\alpha^5)^{n-1} \\\\
-\\vdots & \\vdots & \\vdots & \\vdots & \\ddots & \\vdots \\\\
-1 & (\\alpha^{2t-1})^1 & (\\alpha^{2t-1})^2 & (\\alpha^{2t-1})^3 & \\dots & (\\alpha^{2t-1})^{n-1}
-\\end{matrix}
-\\end{aligned}
-```
-
-The entries of the matrix are in `GF(2ᵐ)`. Each element in `GF(2ᵐ)` can be represented
-by an `m`-tuple (a binary column vector of length `m`). If each entry of `H` is replaced
-by its corresponding `m`-tuple, we obtain a binary parity check matrix for the code.
-
-The BCH code is cyclic as its generator polynomial, `g(x)` divides `xⁿ - 1`, so
-`mod (xⁿ - 1, g(x)) = 0`.
-
-You might be interested in consulting [bose1960further](@cite) and [error2024lin](@cite)
-as well.
-
-The ECC Zoo has an [entry for this family](https://errorcorrectionzoo.org/c/q-ary_bch).
-"""
-struct BCH <: AbstractPolynomialCode
-    m::Int
-    t::Int
-    function BCH(m, t)
-        m < 3 && throw(ArgumentError("m must be greater than or equal to 3"))
-        t >= 2^(m - 1) && throw(ArgumentError("t must be less than 2ᵐ ⁻ ¹"))
-        m * t > 2^m - 1 && throw(ArgumentError("m*t must be less than or equal to 2ᵐ - 1"))
-        new(m, t)
-    end
-end
-
 """
 Generator Polynomial of BCH Codes
 
@@ -117,6 +69,4 @@ function parity_matrix(b::BCH)
     return H
 end
 
-code_n(b::BCH) = 2 ^ b.m - 1
-
-code_k(b::BCH) = 2 ^ b.m - 1 - degree(generator_polynomial(BCH(b.m, b.t)))
+code_k(b::BCH) = code_n(b) - degree(generator_polynomial(b))

--- a/lib/QECCore/ext/QECCoreNemoExt/goppa.jl
+++ b/lib/QECCore/ext/QECCoreNemoExt/goppa.jl
@@ -1,5 +1,3 @@
-abstract type AbstractPolynomialCode <: AbstractCECC end
-
 """
     $TYPEDEF
 

--- a/lib/QECCore/src/codes/classical/bch.jl
+++ b/lib/QECCore/src/codes/classical/bch.jl
@@ -39,6 +39,7 @@ struct BCH <: AbstractPolynomialCode
     t::Int
     function BCH(m, t)
         m < 3 && throw(ArgumentError("m must be greater than or equal to 3"))
+        t < 1 && throw(ArgumentError("t must be greater than or equal to 1"))
         t >= 2^(m - 1) && throw(ArgumentError("t must be less than 2ᵐ ⁻ ¹"))
         m * t > 2^m - 1 && throw(ArgumentError("m*t must be less than or equal to 2ᵐ - 1"))
         new(m, t)

--- a/lib/QECCore/src/codes/classical/bch.jl
+++ b/lib/QECCore/src/codes/classical/bch.jl
@@ -1,8 +1,48 @@
-"""BCH codes ([hocquenghem1959codes](@cite), [bose1960class](@cite))."""
-function BCH(args...; kwargs...)
-    ext = Base.get_extension(QECCore, :QECCoreNemoExt)
-    if isnothing(ext)
-        throw("The `BCH` depends on the package `Nemo` but you have not installed or imported it yet. Immediately after you import `Nemo`, the `BCH` will be available.")
+abstract type AbstractPolynomialCode <: AbstractCECC end
+
+"""
+The family of Bose–Chaudhuri–Hocquenghem (BCH) codes, as discovered in 1959 by
+Alexis Hocquenghem [hocquenghem1959codes](@cite), and independently in 1960 by
+Raj Chandra Bose and D.K. Ray-Chaudhuri [bose1960class](@cite).
+
+The BCH code, denoted as `BCH(m, t)`, is defined by `m`, a positive integer that
+specifies the degree of the finite (Galois) field `GF(2ᵐ)`, and `t`, a positive
+integer that indicates the number of correctable errors. The binary parity check
+matrix can be obtained from the following matrix over ``GF(2ᵐ)`` field elements:
+
+```math
+\\begin{aligned}
+\\begin{matrix}
+1 & (\\alpha^1)^1 & (\\alpha^1)^2 & (\\alpha^1)^3 & \\dots & (\\alpha^1)^{n-1} \\\\
+1 & (\\alpha^3)^1 & (\\alpha^3)^2 & (\\alpha^3)^3 & \\dots & (\\alpha^3)^{n-1} \\\\
+1 & (\\alpha^5)^1 & (\\alpha^5)^2 & (\\alpha^5)^3 & \\dots & (\\alpha^5)^{n-1} \\\\
+\\vdots & \\vdots & \\vdots & \\vdots & \\ddots & \\vdots \\\\
+1 & (\\alpha^{2t-1})^1 & (\\alpha^{2t-1})^2 & (\\alpha^{2t-1})^3 & \\dots & (\\alpha^{2t-1})^{n-1}
+\\end{matrix}
+\\end{aligned}
+```
+
+The entries of the matrix are in `GF(2ᵐ)`. Each element in `GF(2ᵐ)` can be represented
+by an `m`-tuple (a binary column vector of length `m`). If each entry of `H` is replaced
+by its corresponding `m`-tuple, we obtain a binary parity check matrix for the code.
+
+The BCH code is cyclic as its generator polynomial, `g(x)` divides `xⁿ - 1`, so
+`mod (xⁿ - 1, g(x)) = 0`.
+
+You might be interested in consulting [bose1960further](@cite) and [error2024lin](@cite)
+as well.
+
+The ECC Zoo has an [entry for this family](https://errorcorrectionzoo.org/c/q-ary_bch).
+"""
+struct BCH <: AbstractPolynomialCode
+    m::Int
+    t::Int
+    function BCH(m, t)
+        m < 3 && throw(ArgumentError("m must be greater than or equal to 3"))
+        t >= 2^(m - 1) && throw(ArgumentError("t must be less than 2ᵐ ⁻ ¹"))
+        m * t > 2^m - 1 && throw(ArgumentError("m*t must be less than or equal to 2ᵐ - 1"))
+        new(m, t)
     end
-    return ext.BCH(args...; kwargs...)
 end
+
+code_n(b::BCH) = 2 ^ b.m - 1

--- a/lib/QECCore/test/codes/bch.jl
+++ b/lib/QECCore/test/codes/bch.jl
@@ -2,6 +2,7 @@
     using LinearAlgebra
     using Nemo: matrix, finite_field, GF, minpoly, degree, defining_polynomial, is_irreducible
     using QECCore: BCH, code_k, generator_polynomial, parity_matrix
+    using QECCore.Combinatorics: combinations
 
     # To prove that t-bit error correcting BCH code indeed has minimum distance
     # of at least 2 * t + 1, it is shown that no 2 * t or fewer columns of its
@@ -11,22 +12,20 @@
     # distance of the t-bit error correcting BCH code.
 
     function check_designed_distance(matrix, t)
-        n_cols = size(matrix, 2)
         for num_cols in 1:2 * t
-            for i in 1:n_cols - num_cols + 1
-                combo = matrix[:, i:(i + num_cols - 1)]
-                sum_cols = sum(combo, dims = 2)
-                if all(sum_cols .== 0)
-                    return false  # Minimum distance is not greater than `2 * t`.
-                end
+            for cols in combinations(axes(matrix, 2), num_cols)
+                any(isodd, sum(matrix[:, cols]; dims = 2)) || return false
             end
         end
-        return true  # Minimum distance is at least `2 * t + 1`.
+        return true
     end
 
     @testset "Testing properties of BCH codes" begin
         @test BCH isa DataType
         @test BCH(3, 1) isa BCH
+        @test !check_designed_distance(Bool[1 1; 0 0], 1)
+        @test check_designed_distance(parity_matrix(BCH(3, 1)), 1)
+        @test check_designed_distance(parity_matrix(BCH(3, 2)), 2)
 
         m_cases = [3, 4, 5, 6, 7, 8, 9, 10]
         for m in m_cases
@@ -35,9 +34,8 @@
             @test lower_bound < n
             for t in [1,2]
                 H = parity_matrix(BCH(m, t))
-                @test check_designed_distance(H, t) == true
                 # n - k == degree of generator polynomial, `g(x)` == rank of binary parity check matrix, `H`.
-                mat = matrix(GF(2), parity_matrix(BCH(m, t)))
+                mat = matrix(GF(2), H)
                 computed_rank = rank(mat)
                 @test computed_rank == degree(generator_polynomial(BCH(m, t)))
                 @test code_k(BCH(m, t)) == n - degree(generator_polynomial(BCH(m, t)))
@@ -72,7 +70,7 @@
         # where p is a prime number. The GF(2⁶)'s Conway polynomial is p(z) = z⁶ + z⁴ + z³ + z + 1. In contrast,
         # the polynomial given in https://web.ntpu.edu.tw/~yshan/BCH_code.pdf is p(z) = z⁶ + z + 1. Because both
         # polynomials are irreducible, they are also primitive polynomials for `GF(2⁶)`.
-    
+
         test_cases = [(6, 1), (6, 2), (6, 3), (6, 4), (6, 5), (6, 6), (6, 7)]
         @test defining_polynomial(GF2x, GF2⁶) == x ^ 6 + x ^ 4 + x ^ 3 + x + 1
         @test is_irreducible(defining_polynomial(GF2x, GF2⁶)) == true
@@ -89,7 +87,6 @@
         results = [57 51 45 39 36 30 24]
         for (result, (m, t)) in zip(results, test_cases)
             @test code_k(BCH(m, t)) == result
-            @test check_designed_distance(parity_matrix(BCH(m, t)), t) == true
         end
 
         # Reproduce some results from Table, page 8-9 of https://web.ntpu.edu.tw/~yshan/BCH_code.pdf.

--- a/lib/QECCore/test/codes/bch.jl
+++ b/lib/QECCore/test/codes/bch.jl
@@ -23,6 +23,8 @@
     @testset "Testing properties of BCH codes" begin
         @test BCH isa DataType
         @test BCH(3, 1) isa BCH
+        @test_throws ArgumentError BCH(3, -3)
+        @test_throws ArgumentError BCH(3, 0)
         @test !check_designed_distance(Bool[1 1; 0 0], 1)
         @test check_designed_distance(parity_matrix(BCH(3, 1)), 1)
         @test check_designed_distance(parity_matrix(BCH(3, 2)), 2)

--- a/lib/QECCore/test/codes/bch.jl
+++ b/lib/QECCore/test/codes/bch.jl
@@ -1,10 +1,7 @@
 @testitem "ECC BCH" begin
     using LinearAlgebra
-    using QECCore 
-    using QuantumClifford.ECC
-    using Nemo: ZZ, residue_ring, matrix, finite_field, GF, minpoly, coeff, lcm, FqPolyRingElem, FqFieldElem, is_zero, degree, defining_polynomial, is_irreducible
-
-    using QECCore: code_k, code_n, distance, rate, parity_matrix, BCH, generator_polynomial
+    using Nemo: matrix, finite_field, GF, minpoly, degree, defining_polynomial, is_irreducible
+    using QECCore: BCH, code_k, generator_polynomial, parity_matrix
 
     # To prove that t-bit error correcting BCH code indeed has minimum distance
     # of at least 2 * t + 1, it is shown that no 2 * t or fewer columns of its
@@ -28,6 +25,9 @@
     end
 
     @testset "Testing properties of BCH codes" begin
+        @test BCH isa DataType
+        @test BCH(3, 1) isa BCH
+
         m_cases = [3, 4, 5, 6, 7, 8, 9, 10]
         for m in m_cases
             n = 2 ^ m - 1

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -2,7 +2,8 @@ module ECC
 
 using QECCore
 import QECCore: code_n, code_s, code_k, rate, distance, parity_matrix_x, parity_matrix_z, parity_matrix,
-metacheck_matrix_x, metacheck_matrix_z, metacheck_matrix, hgp, generator_polynomial, hasmetachecks
+metacheck_matrix_x, metacheck_matrix_z, metacheck_matrix, hgp, generator_polynomial, hasmetachecks,
+AbstractPolynomialCode
 using QuantumClifford: QuantumClifford, AbstractOperation, AbstractStabilizer,
     AbstractTwoQubitOperator, Stabilizer, PauliOperator,
     random_brickwork_clifford_circuit, random_all_to_all_clifford_circuit,

--- a/test/test_bch_namespace.jl
+++ b/test/test_bch_namespace.jl
@@ -1,0 +1,8 @@
+@testitem "BCH namespace compatibility" begin
+    import QECCore
+    import QuantumClifford
+
+    @test QuantumClifford.ECC.BCH === QECCore.BCH
+    @test QuantumClifford.ECC.AbstractPolynomialCode === QECCore.AbstractPolynomialCode
+    @test QuantumClifford.ECC.BCH(3, 1) isa QECCore.BCH
+end

--- a/test/test_ecc_throws.jl
+++ b/test/test_ecc_throws.jl
@@ -8,8 +8,7 @@
 
     @test_throws ArgumentError BCH(2, 2)
     @test_throws ArgumentError BCH(-2, 2)
-    @test_throws ArgumentError BCH(3, -3)
-    @test_throws ArgumentError BCH(3, 0)
+    @test_throws ArgumentError BCH(2, -3)
     @test_throws ArgumentError BCH(3, 3)
     @test_throws ArgumentError BCH(3, 4)
     @test_throws ArgumentError BCH(4, 4)

--- a/test/test_ecc_throws.jl
+++ b/test/test_ecc_throws.jl
@@ -1,6 +1,12 @@
 @testitem "ECC throws" tags=[:ecc, :ecc_base] begin
 
+    import QECCore
+    import QuantumClifford
     using QuantumClifford.ECC: ReedMuller, BCH, RecursiveReedMuller, Golay, Triangular488, Triangular666, Hamming
+
+    @test QuantumClifford.ECC.BCH === QECCore.BCH
+    @test QuantumClifford.ECC.AbstractPolynomialCode === QECCore.AbstractPolynomialCode
+    @test BCH(3, 1) isa BCH
 
     @test_throws ArgumentError ReedMuller(-1, 3)
     @test_throws ArgumentError ReedMuller(1, 0)

--- a/test/test_ecc_throws.jl
+++ b/test/test_ecc_throws.jl
@@ -14,7 +14,8 @@
 
     @test_throws ArgumentError BCH(2, 2)
     @test_throws ArgumentError BCH(-2, 2)
-    @test_throws ArgumentError BCH(2, -3)
+    @test_throws ArgumentError BCH(3, -3)
+    @test_throws ArgumentError BCH(3, 0)
     @test_throws ArgumentError BCH(3, 3)
     @test_throws ArgumentError BCH(3, 4)
     @test_throws ArgumentError BCH(4, 4)

--- a/test/test_ecc_throws.jl
+++ b/test/test_ecc_throws.jl
@@ -1,12 +1,6 @@
 @testitem "ECC throws" tags=[:ecc, :ecc_base] begin
 
-    import QECCore
-    import QuantumClifford
     using QuantumClifford.ECC: ReedMuller, BCH, RecursiveReedMuller, Golay, Triangular488, Triangular666, Hamming
-
-    @test QuantumClifford.ECC.BCH === QECCore.BCH
-    @test QuantumClifford.ECC.AbstractPolynomialCode === QECCore.AbstractPolynomialCode
-    @test BCH(3, 1) isa BCH
 
     @test_throws ArgumentError ReedMuller(-1, 3)
     @test_throws ArgumentError ReedMuller(1, 0)


### PR DESCRIPTION
Stacked on QuantumSavory/QuantumClifford.jl#698. This targets `fa/move-bch`, so the diff contains only the follow-up fixes.

## Summary

- Define `BCH` and `AbstractPolynomialCode` in QECCore core, with only Nemo-dependent methods in the extension.
- Preserve `QuantumClifford.ECC.BCH === QECCore.BCH` and the old abstract-type binding.
- Reject nonpositive BCH error counts.
- Correct the designed-distance test to check all column combinations over GF(2).
- Add general-CI namespace coverage and root/QECCore changelog entries.

## Validation

- `Pkg.test("QECCore")`: 45,804 passed.
- `Pkg.test("QuantumClifford"; test_args=["general"])`: 350,859 passed, 9 broken.
- Verified construction without Nemo, Nemo extension methods, old/new type identity, and deserialization of a value serialized from the old namespace.
- The ECC base shard adds one passing BCH assertion. Its three unrelated errors reproduce unchanged on the original PR head.

## Release sequencing

Before the next QuantumClifford release, publish a new QECCore version containing this API and raise QuantumClifford’s QECCore lower bound above 0.1.3. This remains separate to match the repository’s release-preparation workflow.